### PR TITLE
Updated composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/log": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
         "league/flysystem": "^1.0",
         "php-ffmpeg/php-ffmpeg": "~0.6",
-        "symfony/process": "^2.5|^3.0" 
+        "symfony/process": "^2.5|^3.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/config": "^5.1",
-        "illuminate/filesystem": "^5.1",
-        "illuminate/log": "^5.1",
+        "illuminate/config": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
+        "illuminate/filesystem": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
+        "illuminate/log": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
         "league/flysystem": "^1.0",
         "php-ffmpeg/php-ffmpeg": "~0.6",
-        "symfony/process": "^2.5|^3.0"
+        "symfony/process": "^2.5|^3.0" 
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.