### PR TITLE
Binary path on env file, default to global install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction
   - sudo add-apt-repository -y ppa:mc3man/trusty-media
   - sudo apt-get -qq update
-  - sudo apt-get install -y software-properties-common ffmpeg
+  - sudo apt-get install -y --allow-unauthenticated software-properties-common ffmpeg
 
 script:
   - phpunit

--- a/config/laravel-ffmpeg.php
+++ b/config/laravel-ffmpeg.php
@@ -3,10 +3,10 @@
 return [
     'default_disk' => 'local',
 
-    'ffmpeg.binaries' => '/usr/local/bin/ffmpeg',
+    'ffmpeg.binaries' => env('FFMPEG_BINARIES','ffmpeg'),
     'ffmpeg.threads'  => 12,
 
-    'ffprobe.binaries' => '/usr/local/bin/ffprobe',
+    'ffprobe.binaries' => env('FFPROBE_BINARIES','ffprobe'),
 
     'timeout' => 3600,
 ];


### PR DESCRIPTION
In most systems (ffmpeg is globally installed) calling just ffmpeg without absolute path will work;
putting the settings in the .env file is a lot better because the configuration may change from dev to production (and will do most of the times)