### PR TITLE
Get frame image as Base64 without saving it.

### DIFF
--- a/src/FrameExporter.php
+++ b/src/FrameExporter.php
@@ -26,6 +26,11 @@ class FrameExporter extends MediaExporter
     {
         return $this->mustBeAccurate;
     }
+    
+    public function getBase64(string $fullPath): string
+    {
+        return $this->media->save($fullPath, $this->getAccuracy(), true);
+    }
 
     public function saveFrame(string $fullPath): MediaExporter
     {


### PR DESCRIPTION
I've added a method in FrameExporter.php that allow the use of $returnBase64 argument for extracted frames...maybe this should be implemented in a better way, but it works.

In this way we can use $video->getFrameFromSeconds(10)->export()->getBase64($path): and get the base64 image directly.

We need also an FFMpeg fix, that was pulled but not merged already.

https://github.com/PHP-FFMpeg/PHP-FFMpeg/pull/534