### PR TITLE
Use nested array for laravel configures.

### DIFF
--- a/config/laravel-ffmpeg-mac-brew.php
+++ b/config/laravel-ffmpeg-mac-brew.php
@@ -3,10 +3,14 @@
 return [
     'default_disk' => 'local',
 
-    'ffmpeg.binaries' => '/usr/local/bin/ffmpeg',
-    'ffmpeg.threads'  => 12,
+    'ffmpeg' => [
+        'binaries' => '/usr/local/bin/ffmpeg',
+        'threads' => 12,
+    ],
 
-    'ffprobe.binaries' => '/usr/local/bin/ffprobe',
+    'ffprobe' => [
+        'binaries' => '/usr/local/bin/ffprobe',
+    ],
 
     'timeout' => 3600,
 ];

--- a/config/laravel-ffmpeg-ubuntu.php
+++ b/config/laravel-ffmpeg-ubuntu.php
@@ -3,10 +3,14 @@
 return [
     'default_disk' => 'local',
 
-    'ffmpeg.binaries' => '/usr/bin/ffmpeg',
-    'ffmpeg.threads'  => 12,
+    'ffmpeg' => [
+        'binaries' => '/usr/bin/ffmpeg',
+        'threads' => 12,
+    ],
 
-    'ffprobe.binaries' => '/usr/bin/ffprobe',
+    'ffprobe' => [
+        'binaries' => '/usr/bin/ffprobe',
+    ],
 
     'timeout' => 3600,
 ];

--- a/config/laravel-ffmpeg.php
+++ b/config/laravel-ffmpeg.php
@@ -3,10 +3,14 @@
 return [
     'default_disk' => 'local',
 
-    'ffmpeg.binaries' => env('FFMPEG_BINARIES','ffmpeg'),
-    'ffmpeg.threads'  => 12,
+    'ffmpeg' => [
+        'binaries' => env('FFMPEG_BINARIES', 'ffmpeg'),
+        'threads' => 12,
+    ],
 
-    'ffprobe.binaries' => env('FFPROBE_BINARIES','ffprobe'),
+    'ffprobe' => [
+        'binaries' => env('FFPROBE_BINARIES', 'ffprobe'),
+    ],
 
     'timeout' => 3600,
 ];


### PR DESCRIPTION
Because of "." at laravel `config()` helper function is meaning "nested array" instead of "string", it should use `'ffmpeg' => ['binaries' => env('FFMPEG_BINARIES', 'ffmpeg)]` instead of `'ffmpeg.binaries' => env('FFMPEG_BINARIES', 'ffmpeg')`