### PR TITLE
Laravel 5.8 Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,292 +2,398 @@
 
 All Notable changes to `pbmedia/laravel-ffmpeg` will be documented in this file
 
+## 4.0.0 - 2019-02-26
+
+### Added
+
+-   Support for Laravel 5.8.
+
+### Deprecated
+
+-   Nothing
+
+### Fixed
+
+-   Nothing
+
+### Removed
+
+-   Nothing
+
+### Security
+
+-   Nothing
+
 ## 3.0.0 - 2018-09-03
 
 ### Added
-- Support for Laravel 5.7.
+
+-   Support for Laravel 5.7.
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Nothing
+
+-   Nothing
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 2.1.0 - 2018-04-10
 
 ### Added
-- Option to disable format sorting in HLS exporter.
+
+-   Option to disable format sorting in HLS exporter.
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Nothing
+
+-   Nothing
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 2.0.1 - 2018-02-30
 
 ### Added
-- Nothing
+
+-   Nothing
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Symfony 4.0 workaround
+
+-   Symfony 4.0 workaround
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 2.0.0 - 2018-02-19
 
 ### Added
-- Support for Laravel 5.6.
+
+-   Support for Laravel 5.6.
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Nothing
+
+-   Nothing
 
 ### Removed
-- Support for Laravel 5.5 and earlier.
+
+-   Support for Laravel 5.5 and earlier.
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 1.3.0 - 2017-11-13
 
 ### Added
-- Support for monitoring the progress of a HLS Export.
+
+-   Support for monitoring the progress of a HLS Export.
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Some refactoring
+
+-   Some refactoring
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 1.2.0 - 2017-11-13
 
 ### Added
-- Support for adding filters per format in the ```HLSPlaylistExporter``` class by giving access to the ```Media``` object through a callback.
+
+-   Support for adding filters per format in the `HLSPlaylistExporter` class by giving access to the `Media` object through a callback.
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Some refactoring
+
+-   Some refactoring
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 1.1.12 - 2017-09-05
 
 ### Added
-- Support for Package Discovery in Laravel 5.5.
+
+-   Support for Package Discovery in Laravel 5.5.
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Some refactoring
+
+-   Some refactoring
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 1.1.11 - 2017-08-31
 
 ### Added
-- Added ```withVisibility``` method to the MediaExporter
+
+-   Added `withVisibility` method to the MediaExporter
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Some refactoring
+
+-   Some refactoring
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 1.1.10 - 2017-08-16
 
 ### Added
-- Added ```getFirstStream()``` method to the ```Media``` class
+
+-   Added `getFirstStream()` method to the `Media` class
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Some refactoring
+
+-   Some refactoring
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 1.1.9 - 2017-07-10
 
 ### Added
-- Support for custom filters in the ```Media``` class
+
+-   Support for custom filters in the `Media` class
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Nothing
+
+-   Nothing
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 1.1.8 - 2017-05-22
 
 ### Added
-- ```getDurationInMiliseconds``` method in Media class
+
+-   `getDurationInMiliseconds` method in Media class
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Nothing
+
+-   Nothing
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 1.1.7 - 2017-05-22
 
 ### Added
-- ```fromFilesystem``` method in FFMpeg class
+
+-   `fromFilesystem` method in FFMpeg class
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Fallback to format properties in ```getDurationInSeconds``` method (Media class)
+
+-   Fallback to format properties in `getDurationInSeconds` method (Media class)
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 1.1.6 - 2017-05-11
 
 ### Added
-- ```cleanupTemporaryFiles``` method
+
+-   `cleanupTemporaryFiles` method
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Nothing
+
+-   Nothing
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 1.1.5 - 2017-03-20
 
 ### Added
-- Nothing
+
+-   Nothing
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Bugfix for saving on remote disks
+
+-   Bugfix for saving on remote disks
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 1.1.4 - 2017-01-29
 
 ### Added
-- Nothing
+
+-   Nothing
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Support for php-ffmpeg 0.8.0
+
+-   Support for php-ffmpeg 0.8.0
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing
 
 ## 1.1.3 - 2017-01-05
 
 ### Added
-- Nothing
+
+-   Nothing
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- HLS segment playlists output path is now relative
+
+-   HLS segment playlists output path is now relative
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
 
+-   Nothing
 
 ## 1.1.2 - 2017-01-05
 
 ### Added
-- Added 'getDurationInSeconds' method to Media class.
+
+-   Added 'getDurationInSeconds' method to Media class.
 
 ### Deprecated
-- Nothing
+
+-   Nothing
 
 ### Fixed
-- Nothing
+
+-   Nothing
 
 ### Removed
-- Nothing
+
+-   Nothing
 
 ### Security
-- Nothing
+
+-   Nothing

--- a/README.md
+++ b/README.md
@@ -6,18 +6,25 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/pascalbaljetmedia/laravel-ffmpeg.svg?style=flat-square)](https://scrutinizer-ci.com/g/pascalbaljetmedia/laravel-ffmpeg)
 [![Total Downloads](https://img.shields.io/packagist/dt/pbmedia/laravel-ffmpeg.svg?style=flat-square)](https://packagist.org/packages/pbmedia/laravel-ffmpeg)
 
-This package provides an integration with FFmpeg for Laravel 5.7. The storage of the files is handled by [Laravel's Filesystem](http://laravel.com/docs/5.7/filesystem).
+This package provides an integration with FFmpeg for Laravel 5.8. The storage of the files is handled by [Laravel's Filesystem](http://laravel.com/docs/5.8/filesystem).
 
 ## Features
 * Super easy wrapper around [PHP-FFMpeg](https://github.com/PHP-FFMpeg/PHP-FFMpeg), including support for filters and other advanced features.
-* Integration with [Laravel's Filesystem](http://laravel.com/docs/5.7/filesystem), [configuration system](https://laravel.com/docs/5.7/configuration) and [logging handling](https://laravel.com/docs/5.7/errors).
-* Compatible with Laravel 5.7.
-* Support for [Package Discovery](https://laravel.com/docs/5.7/packages#package-discovery).
+* Integration with [Laravel's Filesystem](http://laravel.com/docs/5.8/filesystem), [configuration system](https://laravel.com/docs/5.8/configuration) and [logging handling](https://laravel.com/docs/5.8/errors).
+* Compatible with Laravel 5.8.
+* Support for [Package Discovery](https://laravel.com/docs/5.8/packages#package-discovery).
 * PHP 7.1 and 7.2 only.
 
 ## Installation
 
-This version of the package is only compatible with Laravel 5.7. If you're still using Laravel 5.1 - 5.5, please use version 1.3, for Laravel 5.6 use version 2.1. Mind that older versions are not supported anymore.
+The master branch and version 4.0 of this package is only compatible with Laravel 5.8. If you're still using previous versions of Laravel, please use the below chart to determine which version of this package you should use. Mind that older versions are no longer supported.
+
+| Laravel Version | Package Version |
+|-----------------|-----------------|
+| 5.8             | 4.0             |
+| 5.7             | 3.0             |
+| 5.6             | 2.1             |
+| 5.1-5.5         | 1.3             |
 
 You can install the package via composer:
 

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php": "^7.1",
-        "illuminate/config": "5.7.*",
-        "illuminate/filesystem": "5.7.*",
-        "illuminate/log": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "illuminate/config": "5.8.*",
+        "illuminate/filesystem": "5.8.*",
+        "illuminate/log": "5.8.*",
+        "illuminate/support": "5.8.*",
         "league/flysystem": "~1.0",
         "php-ffmpeg/php-ffmpeg": "^0.13",
         "symfony/process": "~4.0"

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,7 +20,7 @@ class TestCase extends PHPUnitTestCase
 
     public $remoteFilesystem;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->srcDir = __DIR__ . '/src';
 


### PR DESCRIPTION
Hi there,

Thanks for the package. This PR changes the primary support to Laravel 5.8 & assumes that you'll tag the next version as 4.0.0. I also added a version table to the README to help direct users to which version they should be using.

