### PR TITLE
feat: Add hardware acceleration, x265 codec options, and image-to-vid…

### DIFF
--- a/src/FFMpeg/ImageFormat.php
+++ b/src/FFMpeg/ImageFormat.php
@@ -6,6 +6,8 @@ use FFMpeg\Format\Video\DefaultVideo;
 
 class ImageFormat extends DefaultVideo
 {
+    protected $duration = null;
+
     public function __construct()
     {
         $this->kiloBitrate = 0;
@@ -13,11 +15,26 @@ class ImageFormat extends DefaultVideo
     }
 
     /**
+     * Set the duration for image-to-video conversion.
+     *
+     * @param float $duration
+     * @return $this
+     */
+    public function setDuration(float $duration): self
+    {
+        if ($duration <= 0) {
+            throw new \InvalidArgumentException('Duration must be greater than 0.');
+        }
+        $this->duration = $duration;
+        return $this;
+    }
+
+    /**
      * Gets the kiloBitrate value.
      *
      * @return int
      */
-    public function getKiloBitrate()
+    public function getKiloBitrate(): int
     {
         return $this->kiloBitrate;
     }
@@ -32,7 +49,7 @@ class ImageFormat extends DefaultVideo
      *
      * @return int
      */
-    public function getModulus()
+    public function getModulus(): int
     {
         return 0;
     }
@@ -40,9 +57,9 @@ class ImageFormat extends DefaultVideo
     /**
      * Returns the video codec.
      *
-     * @return string
+     * @return string|null
      */
-    public function getVideoCodec()
+    public function getVideoCodec(): ?string
     {
         return null;
     }
@@ -54,7 +71,7 @@ class ImageFormat extends DefaultVideo
      *
      * @return bool
      */
-    public function supportBFrames()
+    public function supportBFrames(): bool
     {
         return false;
     }
@@ -64,7 +81,7 @@ class ImageFormat extends DefaultVideo
      *
      * @return array
      */
-    public function getAvailableVideoCodecs()
+    public function getAvailableVideoCodecs(): array
     {
         return [];
     }
@@ -74,9 +91,18 @@ class ImageFormat extends DefaultVideo
      *
      * @return array
      */
-    public function getAdditionalParameters()
+    public function getAdditionalParameters(): array
     {
-        return ['-f', 'image2'];
+        $parameters = ['-f', 'image2'];
+
+        if ($this->duration !== null) {
+            $parameters[] = '-loop';
+            $parameters[] = '1';
+            $parameters[] = '-t';
+            $parameters[] = $this->duration;
+        }
+
+        return $parameters;
     }
 
     /**
@@ -84,7 +110,7 @@ class ImageFormat extends DefaultVideo
      *
      * @return array
      */
-    public function getInitialParameters()
+    public function getInitialParameters(): array
     {
         return [];
     }
@@ -92,7 +118,7 @@ class ImageFormat extends DefaultVideo
     /**
      * {@inheritdoc}
      */
-    public function getExtraParams()
+    public function getExtraParams(): array
     {
         return [];
     }
@@ -100,7 +126,7 @@ class ImageFormat extends DefaultVideo
     /**
      * {@inheritDoc}
      */
-    public function getAvailableAudioCodecs()
+    public function getAvailableAudioCodecs(): array
     {
         return [];
     }


### PR DESCRIPTION
…eo conversion

* feat: Add hardware acceleration and x265 codec options

This commit introduces several new features:

- Added `withHardwareAcceleration` method to `MediaExporter` and `HLSExporter` to enable hardware acceleration using specified codecs (e.g., 'h264_nvenc', 'hevc_nvenc').
- Added `useX265` method to `HLSExporter` to enable the x265 codec for HLS encoding.
- Added `toVideoFromImage` method to `MediaExporter` to convert an image to a video with a specified duration.
- Added `useX265` and `withHardwareAcceleration` methods to `MediaOpener` for easy access.
- Updated `Media` class to resolve and validate temporary paths.
- Improved error handling by including FFmpeg error output in exception messages.

* feat: Implement image-to-video conversion

Added `ImageFormat` class to handle image-to-video conversion with specified duration.

* fix: Improve temporary file handling and error reporting

- Fixed an issue where temporary files were not being handled correctly.
- Improved error reporting by including FFmpeg error output in exception messages.
- Added validation for temporary paths in the `Media` class.