### PR TITLE
Fix #493: Add missing @method annotations to FFMpeg facade

### DIFF
--- a/src/Support/FFMpeg.php
+++ b/src/Support/FFMpeg.php
@@ -10,6 +10,12 @@ use Illuminate\Support\Facades\Facade;
  * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener fromFilesystem(\Illuminate\Contracts\Filesystem\Filesystem $filesystem)
  * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener open($path)
  * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener openUrl($path, array $headers = [])
+ * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener openWithInputOptions(string $path, array $options = [])
+ * @method static \ProtoneMedia\LaravelFFMpeg\Exporters\MediaExporter export()
+ * @method static \ProtoneMedia\LaravelFFMpeg\Exporters\HLSExporter exportForHLS()
+ * @method static \ProtoneMedia\LaravelFFMpeg\Exporters\MediaExporter exportTile(callable $withTileFactory)
+ * @method static \ProtoneMedia\LaravelFFMpeg\Exporters\MediaExporter exportFramesByAmount(int $amount, ?int $width = null, ?int $height = null, ?int $quality = null)
+ * @method static \ProtoneMedia\LaravelFFMpeg\Exporters\MediaExporter exportFramesByInterval(float $interval, ?int $width = null, ?int $height = null, ?int $quality = null)
  * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener cleanupTemporaryFiles()
  *
  * @see \ProtoneMedia\LaravelFFMpeg\MediaOpener


### PR DESCRIPTION
## Summary

Fixes #493.

This is **not a code bug** — the `exportTile()` method is correctly defined on `MediaOpener` (line 209) and works at runtime. The reported error is most likely caused by using an older version of the package that predates the addition of `exportTile()`.

However, the `FFMpeg` facade was missing `@method` PHPDoc annotations for several public methods on `MediaOpener`, including `exportTile()`, `export()`, `exportForHLS()`, `exportFramesByAmount()`, `exportFramesByInterval()`, and `openWithInputOptions()`. This causes IDEs and static analysis tools (PHPStan, Psalm, Larastan) to report these methods as undefined, which can lead to confusion.

This PR adds the missing `@method` annotations to the facade docblock.

## Changes

- Added `@method` annotations to `FFMpeg` facade for:
  - `openWithInputOptions()`
  - `export()`
  - `exportForHLS()`
  - `exportTile()`
  - `exportFramesByAmount()`
  - `exportFramesByInterval()`

## Test plan

- No runtime behavior changes — PHPDoc annotations only
- Verified all annotated methods exist on `MediaOpener` with matching signatures
- Existing test suite (`TileTest`) covers `exportTile()` functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)